### PR TITLE
Allow devs to skip check on specific lines

### DIFF
--- a/modules/requirements.js
+++ b/modules/requirements.js
@@ -16,7 +16,7 @@ function pushInvalidLines(patch, invalid_versions) {
             if (!clean_line || clean_line.startsWith('#')) { return; }
             // only take violations to the PEP 440 rule (https://stackoverflow.com/questions/37972029/regex-to-match-pep440-compliant-version-strings)
             // and allow eggs
-            var regex = 'git\\+ssh:\\/\\/git@[\\S]+\.[\\S]+@[\\d]+\.[\\d]+(?:\\.[\\d]+)?#egg=[\\S]+|[\\S]+==(?:\\d+!)?\\d+(?:\\.\\d+)(?:\\.\\d+)?(?:[\\.\\-\\_](?:a(?:lpha)?|b(?:eta)?|c|r(?:c|ev)?|pre(?:view)?)\\d*)?(?:\\.?(?:post|dev)\\d*)?'
+            var regex = 'git\\+ssh:\\/\\/git@[\\S]+\.[\\S]+@[\\d]+\.[\\d]+(?:\\.[\\d]+)?#egg=[\\S]+|[\\S]+==(?:\\d+!)?\\d+(?:\\.\\d+)(?:\\.\\d+)?(?:[\\.\\-\\_](?:a(?:lpha)?|b(?:eta)?|c|r(?:c|ev)?|pre(?:view)?)\\d*)?(?:\\.?(?:post|dev)\\d*)?|.*\\s#no-qa'
             var matches = clean_line.match(regex);
             // if there's no match or the line doesn't equal the entire match, it's invalid
             if (!matches || matches[0] !== clean_line) {


### PR DESCRIPTION
Observed problem:
In this PR: https://github.com/vikingco/mvne-platform/pull/7340/files#diff-444e80f30bd2f1e25b779966c9621b9bR285 we
wanted to bump the version of a direct dependency to a pre-build package. This PR got rejected because it did not match
our regex. This is however allowed by the PEP standard as seen here:
https://www.python.org/dev/peps/pep-0440/#direct-references

Proposed solution:
Allow devs to add a trailing ` #no-qa` to a dependency to skip the check. This should be used sparsely and thoroughly
checked during code review that there is no alternative way to add the dependency